### PR TITLE
Proper random

### DIFF
--- a/common/src/main/java/ru/maxthetomas/e418/E418.java
+++ b/common/src/main/java/ru/maxthetomas/e418/E418.java
@@ -15,6 +15,7 @@ import ru.maxthetomas.e418.event.engine.ChatMessageEventManager;
 import ru.maxthetomas.e418.event.engine.RandomEventManager;
 import ru.maxthetomas.e418.networking.E418Networking;
 import ru.maxthetomas.e418.util.E418ClientVariables;
+import ru.maxthetomas.e418.util.E418Random;
 import ru.maxthetomas.e418.util.E418Variables;
 
 import java.util.Optional;
@@ -42,6 +43,7 @@ public final class E418 {
         LifecycleEvent.SERVER_BEFORE_START.register(srv -> {
             ManagedServer = srv;
             E418Variables.init();
+            E418Random.init(srv);
         });
 
         LifecycleEvent.SERVER_STOPPING.register(srv -> {

--- a/common/src/main/java/ru/maxthetomas/e418/E418.java
+++ b/common/src/main/java/ru/maxthetomas/e418/E418.java
@@ -43,7 +43,13 @@ public final class E418 {
         LifecycleEvent.SERVER_BEFORE_START.register(srv -> {
             ManagedServer = srv;
             E418Variables.init();
-            E418Random.init(srv);
+
+        });
+
+        LifecycleEvent.SERVER_LEVEL_LOAD.register(lvl -> {
+            if (lvl == ManagedServer.overworld()) {
+                E418Random.init(lvl);
+            }
         });
 
         LifecycleEvent.SERVER_STOPPING.register(srv -> {

--- a/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomLocationAroundPlayerContextMutator.java
+++ b/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomLocationAroundPlayerContextMutator.java
@@ -8,6 +8,7 @@ import net.minecraft.util.RandomSource;
 import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.behaviour.contextmutators.IContextMutator;
 import ru.maxthetomas.e418.event.EventContext;
+import ru.maxthetomas.e418.util.E418Random;
 import ru.maxthetomas.e418.util.Location;
 
 public class SelectRandomLocationAroundPlayerContextMutator implements IContextMutator {
@@ -47,7 +48,7 @@ public class SelectRandomLocationAroundPlayerContextMutator implements IContextM
         if (randomSequence != null) {
             random = context.getServer().overworld().getRandomSequence(randomSequence);
         } else {
-            random = context.getServer().overworld().getRandom();
+            random = E418Random.EVENT_GENERIC;
         }
 
         var position = location.position();

--- a/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomLocationAroundPlayerContextMutator.java
+++ b/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomLocationAroundPlayerContextMutator.java
@@ -17,7 +17,7 @@ public class SelectRandomLocationAroundPlayerContextMutator implements IContextM
             instance -> instance.group(
                     Codec.FLOAT.optionalFieldOf("radius", 16.0f)
                             .forGetter(SelectRandomLocationAroundPlayerContextMutator::getRange),
-                    ResourceLocation.CODEC.optionalFieldOf("random_sequence", null)
+                    ResourceLocation.CODEC.optionalFieldOf("random_sequence", E418Random.EVENT_GENERIC_RESOURCE)
                             .forGetter(SelectRandomLocationAroundPlayerContextMutator::getRandomSequence)
             ).apply(instance, SelectRandomLocationAroundPlayerContextMutator::new));
 
@@ -45,11 +45,8 @@ public class SelectRandomLocationAroundPlayerContextMutator implements IContextM
         var location = Location.fromPlayer(player);
 
         RandomSource random;
-        if (randomSequence != null) {
-            random = context.getServer().overworld().getRandomSequence(randomSequence);
-        } else {
-            random = E418Random.EVENT_GENERIC;
-        }
+
+        random = context.getServer().overworld().getRandomSequence(randomSequence);
 
         var position = location.position();
         position.add(

--- a/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomLocationAroundPlayerContextMutator.java
+++ b/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomLocationAroundPlayerContextMutator.java
@@ -15,17 +15,25 @@ public class SelectRandomLocationAroundPlayerContextMutator implements IContextM
     public static final MapCodec<SelectRandomLocationAroundPlayerContextMutator> CODEC = RecordCodecBuilder.mapCodec(
             instance -> instance.group(
                     Codec.FLOAT.optionalFieldOf("radius", 16.0f)
-                            .forGetter(SelectRandomLocationAroundPlayerContextMutator::getRange)
+                            .forGetter(SelectRandomLocationAroundPlayerContextMutator::getRange),
+                    ResourceLocation.CODEC.optionalFieldOf("random_sequence", null)
+                            .forGetter(SelectRandomLocationAroundPlayerContextMutator::getRandomSequence)
             ).apply(instance, SelectRandomLocationAroundPlayerContextMutator::new));
 
     private final float range;
+    private final ResourceLocation randomSequence;
 
-    public SelectRandomLocationAroundPlayerContextMutator(float range) {
+    public SelectRandomLocationAroundPlayerContextMutator(float range, ResourceLocation randomSequence) {
         this.range = range;
+        this.randomSequence = randomSequence;
     }
 
     public float getRange() {
         return range;
+    }
+
+    private ResourceLocation getRandomSequence() {
+        return randomSequence;
     }
 
     @Override
@@ -34,7 +42,13 @@ public class SelectRandomLocationAroundPlayerContextMutator implements IContextM
         if (player == null) return false;
 
         var location = Location.fromPlayer(player);
-        var random = RandomSource.create();
+
+        RandomSource random;
+        if (randomSequence != null) {
+            random = context.getServer().overworld().getRandomSequence(randomSequence);
+        } else {
+            random = context.getServer().overworld().getRandom();
+        }
 
         var position = location.position();
         position.add(

--- a/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomPlayerContextMutator.java
+++ b/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomPlayerContextMutator.java
@@ -19,7 +19,7 @@ public class SelectRandomPlayerContextMutator implements IContextMutator {
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(E418.MOD_ID, "select_random_player");
     public static final MapCodec<SelectRandomPlayerContextMutator> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.BOOL.optionalFieldOf("prevent_override", false).forGetter(SelectRandomPlayerContextMutator::isPreventOverride),
-            ResourceLocation.CODEC.optionalFieldOf("random_sequence", null).forGetter(SelectRandomPlayerContextMutator::getRandomSequence)
+            ResourceLocation.CODEC.optionalFieldOf("random_sequence", E418Random.EVENT_GENERIC_RESOURCE).forGetter(SelectRandomPlayerContextMutator::getRandomSequence)
     ).apply(instance, SelectRandomPlayerContextMutator::new));
 
     private final boolean preventOverride;
@@ -52,11 +52,7 @@ public class SelectRandomPlayerContextMutator implements IContextMutator {
 
         RandomSource random;
 
-        if (randomSequence != null) {
-            random = context.getServer().overworld().getRandomSequence(randomSequence);
-        } else {
-            random = E418Random.EVENT_GENERIC;
-        }
+        random = context.getServer().overworld().getRandomSequence(randomSequence);
 
         ServerPlayer target = playerList.get(random.nextIntBetweenInclusive(0, playerList.size() - 1));
         context.withPlayer(target);

--- a/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomPlayerContextMutator.java
+++ b/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomPlayerContextMutator.java
@@ -5,6 +5,8 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.RandomSource;
+import org.jetbrains.annotations.Nullable;
 import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.behaviour.contextmutators.IContextMutator;
 import ru.maxthetomas.e418.event.EventContext;
@@ -15,13 +17,16 @@ import ru.maxthetomas.e418.event.EventContext;
 public class SelectRandomPlayerContextMutator implements IContextMutator {
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(E418.MOD_ID, "select_random_player");
     public static final MapCodec<SelectRandomPlayerContextMutator> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-            Codec.BOOL.optionalFieldOf("prevent_override", false).forGetter(SelectRandomPlayerContextMutator::isPreventOverride)
+            Codec.BOOL.optionalFieldOf("prevent_override", false).forGetter(SelectRandomPlayerContextMutator::isPreventOverride),
+            ResourceLocation.CODEC.optionalFieldOf("random_sequence", null).forGetter(SelectRandomPlayerContextMutator::getRandomSequence)
     ).apply(instance, SelectRandomPlayerContextMutator::new));
 
     private final boolean preventOverride;
+    private final ResourceLocation randomSequence;
 
-    public SelectRandomPlayerContextMutator(boolean preventOverride) {
+    public SelectRandomPlayerContextMutator(boolean preventOverride, ResourceLocation randomSequence) {
         this.preventOverride = preventOverride;
+        this.randomSequence = randomSequence;
     }
 
     /**
@@ -43,8 +48,14 @@ public class SelectRandomPlayerContextMutator implements IContextMutator {
 
         if (playerList.isEmpty())
             return false;
+        
+        RandomSource random;
 
-        var random = context.getServer().overworld().getRandom();
+        if (randomSequence != null) {
+            random = context.getServer().overworld().getRandomSequence(randomSequence);
+        } else {
+            random = context.getServer().overworld().getRandom();
+        }
 
         ServerPlayer target = playerList.get(random.nextIntBetweenInclusive(0, playerList.size() - 1));
         context.withPlayer(target);
@@ -55,5 +66,10 @@ public class SelectRandomPlayerContextMutator implements IContextMutator {
     @Override
     public ResourceLocation getType() {
         return ID;
+    }
+
+    @Nullable
+    private ResourceLocation getRandomSequence() {
+        return randomSequence;
     }
 }

--- a/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomPlayerContextMutator.java
+++ b/common/src/main/java/ru/maxthetomas/e418/behaviour/contextmutators/impl/SelectRandomPlayerContextMutator.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.behaviour.contextmutators.IContextMutator;
 import ru.maxthetomas.e418.event.EventContext;
+import ru.maxthetomas.e418.util.E418Random;
 
 /**
  * Mutates context to have random player.
@@ -48,13 +49,13 @@ public class SelectRandomPlayerContextMutator implements IContextMutator {
 
         if (playerList.isEmpty())
             return false;
-        
+
         RandomSource random;
 
         if (randomSequence != null) {
             random = context.getServer().overworld().getRandomSequence(randomSequence);
         } else {
-            random = context.getServer().overworld().getRandom();
+            random = E418Random.EVENT_GENERIC;
         }
 
         ServerPlayer target = playerList.get(random.nextIntBetweenInclusive(0, playerList.size() - 1));

--- a/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
+++ b/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
@@ -19,7 +19,7 @@ public record RandomNumberProvider(float min, float max,
     public static MapCodec<RandomNumberProvider> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.FLOAT.fieldOf("min").forGetter(RandomNumberProvider::min),
             Codec.FLOAT.fieldOf("max").forGetter(RandomNumberProvider::max),
-            ResourceLocation.CODEC.optionalFieldOf("random_sequence", null).forGetter(RandomNumberProvider::randomSequence)
+            ResourceLocation.CODEC.optionalFieldOf("random_sequence", E418Random.EVENT_GENERIC_RESOURCE).forGetter(RandomNumberProvider::randomSequence)
     ).apply(instance, RandomNumberProvider::new));
 
     @Override
@@ -31,12 +31,8 @@ public record RandomNumberProvider(float min, float max,
     public Number get(EventContext context, NumberRequester requester) {
         RandomSource source;
 
-        if (randomSequence != null) {
-            source = context.getServer().overworld().getRandomSequence(randomSequence);
-        } else {
-            source = E418Random.EVENT_GENERIC;
-        }
-
+        source = context.getServer().overworld().getRandomSequence(randomSequence);
+        
         return min + (source.nextFloat() * max - min);
     }
 }

--- a/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
+++ b/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
@@ -10,17 +10,15 @@ import ru.maxthetomas.e418.codecs.NumberProvider;
 import ru.maxthetomas.e418.codecs.NumberRequester;
 import ru.maxthetomas.e418.event.EventContext;
 
-import java.util.Optional;
-
 public record RandomNumberProvider(float min, float max,
-                                   Optional<ResourceLocation> randomSequence) implements NumberProvider {
+                                   ResourceLocation randomSequence) implements NumberProvider {
     public static ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(
             E418.MOD_ID, "random"
     );
     public static MapCodec<RandomNumberProvider> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.FLOAT.fieldOf("min").forGetter(RandomNumberProvider::min),
             Codec.FLOAT.fieldOf("max").forGetter(RandomNumberProvider::max),
-            ResourceLocation.CODEC.optionalFieldOf("random_sequence").forGetter(RandomNumberProvider::randomSequence)
+            ResourceLocation.CODEC.optionalFieldOf("random_sequence", null).forGetter(RandomNumberProvider::randomSequence)
     ).apply(instance, RandomNumberProvider::new));
 
     @Override
@@ -32,12 +30,10 @@ public record RandomNumberProvider(float min, float max,
     public Number get(EventContext context, NumberRequester requester) {
         RandomSource source;
 
-        if (randomSequence.isPresent()) {
-            source = context.getServer().overworld().getRandomSequence(randomSequence.get());
+        if (randomSequence != null) {
+            source = context.getServer().overworld().getRandomSequence(randomSequence);
         } else {
-            var code = ((context.getSourceEvent().hashCode() + requester.hashCode()
-                    + context.getSourceEvent().startTime) << 8) ^ 0x24869;
-            source = RandomSource.create(code);
+            source = context.getServer().overworld().getRandom();
         }
 
         return min + (source.nextFloat() * max - min);

--- a/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
+++ b/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
@@ -10,13 +10,17 @@ import ru.maxthetomas.e418.codecs.NumberProvider;
 import ru.maxthetomas.e418.codecs.NumberRequester;
 import ru.maxthetomas.e418.event.EventContext;
 
-public record RandomNumberProvider(float min, float max) implements NumberProvider {
+import java.util.Optional;
+
+public record RandomNumberProvider(float min, float max,
+                                   Optional<ResourceLocation> randomSequence) implements NumberProvider {
     public static ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(
             E418.MOD_ID, "random"
     );
     public static MapCodec<RandomNumberProvider> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Codec.FLOAT.fieldOf("min").forGetter(RandomNumberProvider::min),
-            Codec.FLOAT.fieldOf("max").forGetter(RandomNumberProvider::max)
+            Codec.FLOAT.fieldOf("max").forGetter(RandomNumberProvider::max),
+            ResourceLocation.CODEC.optionalFieldOf("random_sequence").forGetter(RandomNumberProvider::randomSequence)
     ).apply(instance, RandomNumberProvider::new));
 
     @Override
@@ -26,9 +30,16 @@ public record RandomNumberProvider(float min, float max) implements NumberProvid
 
     @Override
     public Number get(EventContext context, NumberRequester requester) {
-        var code = ((context.getSourceEvent().hashCode() + requester.hashCode()
-                + context.getSourceEvent().startTime) << 8) ^ 0x24869;
-        var source = RandomSource.create(code);
+        RandomSource source;
+
+        if (randomSequence.isPresent()) {
+            source = context.getServer().overworld().getRandomSequence(randomSequence.get());
+        } else {
+            var code = ((context.getSourceEvent().hashCode() + requester.hashCode()
+                    + context.getSourceEvent().startTime) << 8) ^ 0x24869;
+            source = RandomSource.create(code);
+        }
+
         return min + (source.nextFloat() * max - min);
     }
 }

--- a/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
+++ b/common/src/main/java/ru/maxthetomas/e418/codecs/impl/RandomNumberProvider.java
@@ -9,6 +9,7 @@ import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.codecs.NumberProvider;
 import ru.maxthetomas.e418.codecs.NumberRequester;
 import ru.maxthetomas.e418.event.EventContext;
+import ru.maxthetomas.e418.util.E418Random;
 
 public record RandomNumberProvider(float min, float max,
                                    ResourceLocation randomSequence) implements NumberProvider {
@@ -33,7 +34,7 @@ public record RandomNumberProvider(float min, float max,
         if (randomSequence != null) {
             source = context.getServer().overworld().getRandomSequence(randomSequence);
         } else {
-            source = context.getServer().overworld().getRandom();
+            source = E418Random.EVENT_GENERIC;
         }
 
         return min + (source.nextFloat() * max - min);

--- a/common/src/main/java/ru/maxthetomas/e418/condition/impl/RandomCondition.java
+++ b/common/src/main/java/ru/maxthetomas/e418/condition/impl/RandomCondition.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
+import org.jetbrains.annotations.Nullable;
 import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.condition.ICondition;
 import ru.maxthetomas.e418.event.EventContext;
@@ -14,17 +15,27 @@ import ru.maxthetomas.e418.event.EventContext;
 public class RandomCondition implements ICondition {
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(E418.MOD_ID, "random");
     public static final MapCodec<RandomCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-            ExtraCodecs.floatRange(0, 1).fieldOf("chance").forGetter(RandomCondition::getChance)
+            ExtraCodecs.floatRange(0, 1).fieldOf("chance").forGetter(RandomCondition::getChance),
+            ResourceLocation.CODEC.optionalFieldOf("randomSequence", null).forGetter(RandomCondition::getRandomSequence)
     ).apply(instance, RandomCondition::new));
 
     private final float chance;
 
-    public RandomCondition(float chance) {
+    @Nullable
+    private final ResourceLocation random_sequence;
+
+    public RandomCondition(float chance, @Nullable ResourceLocation randomSequence) {
         this.chance = chance;
+        random_sequence = randomSequence;
     }
 
     @Override
     public boolean check(EventContext context) {
+        if (random_sequence != null) {
+            var random = context.getServer().overworld().getRandomSequence(random_sequence);
+            return random.nextFloat() < chance;
+        }
+
         return context.getServer().overworld().getRandom().nextFloat() < chance;
     }
 
@@ -35,5 +46,10 @@ public class RandomCondition implements ICondition {
 
     public float getChance() {
         return chance;
+    }
+
+    @Nullable
+    public ResourceLocation getRandomSequence() {
+        return random_sequence;
     }
 }

--- a/common/src/main/java/ru/maxthetomas/e418/condition/impl/RandomCondition.java
+++ b/common/src/main/java/ru/maxthetomas/e418/condition/impl/RandomCondition.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.condition.ICondition;
 import ru.maxthetomas.e418.event.EventContext;
+import ru.maxthetomas.e418.util.E418Random;
 
 /// Returns true only when gamble was worth it
 ///
@@ -36,7 +37,7 @@ public class RandomCondition implements ICondition {
             return random.nextFloat() < chance;
         }
 
-        return context.getServer().overworld().getRandom().nextFloat() < chance;
+        return E418Random.EVENT_GENERIC.nextFloat() < chance;
     }
 
     @Override

--- a/common/src/main/java/ru/maxthetomas/e418/event/engine/ChatMessageEventManager.java
+++ b/common/src/main/java/ru/maxthetomas/e418/event/engine/ChatMessageEventManager.java
@@ -8,6 +8,7 @@ import ru.maxthetomas.e418.E418;
 import ru.maxthetomas.e418.event.EventContext;
 import ru.maxthetomas.e418.event.cause.impl.ChatMessageCause;
 import ru.maxthetomas.e418.event.registry.EventRegistries;
+import ru.maxthetomas.e418.util.E418Random;
 import ru.maxthetomas.e418.util.Location;
 
 public class ChatMessageEventManager {
@@ -24,7 +25,7 @@ public class ChatMessageEventManager {
                 .withLocation(Location.fromPlayer(serverPlayer))
                 .withCause(new ChatMessageCause(component));
 
-        var e = EventRegistries.getQueueableEventsWithTag("action.minecraft.chat_message", ctx).getRandomElement();
+        var e = EventRegistries.getQueueableEventsWithTag("action.minecraft.chat_message", ctx).getRandomElement(E418Random.EVENT_ENGINE_WAKE_UP);
         if (e != null) {
             E418.getEventManager().queueEvent(e, ctx);
         }

--- a/common/src/main/java/ru/maxthetomas/e418/event/engine/ChatMessageEventManager.java
+++ b/common/src/main/java/ru/maxthetomas/e418/event/engine/ChatMessageEventManager.java
@@ -11,12 +11,14 @@ import ru.maxthetomas.e418.event.registry.EventRegistries;
 import ru.maxthetomas.e418.util.Location;
 
 public class ChatMessageEventManager {
+
     public ChatMessageEventManager() {
         ChatEvent.RECEIVED.register((serverPlayer, component) -> serverPlayer != null ? onReceived(serverPlayer, component) : null);
     }
 
     private EventResult onReceived(ServerPlayer serverPlayer, Component component) {
-        // TODO: Randomize so not every message will cause an event. (would be cool to have custom system for messages idk)
+        // TODO: Should have a limit so not every message will try to trigger an event. Can't be just random chance.
+
         var ctx = new EventContext(serverPlayer.getServer())
                 .withPlayer(serverPlayer)
                 .withLocation(Location.fromPlayer(serverPlayer))

--- a/common/src/main/java/ru/maxthetomas/e418/event/engine/RandomEventManager.java
+++ b/common/src/main/java/ru/maxthetomas/e418/event/engine/RandomEventManager.java
@@ -11,6 +11,7 @@ import ru.maxthetomas.e418.event.cause.impl.GlobalRandomEventCause;
 import ru.maxthetomas.e418.event.cause.impl.PlayerRandomEventCause;
 import ru.maxthetomas.e418.event.registry.EventRegistries;
 import ru.maxthetomas.e418.player.PlayerDataManager;
+import ru.maxthetomas.e418.util.E418Random;
 import ru.maxthetomas.e418.util.Location;
 
 public class RandomEventManager {
@@ -43,7 +44,7 @@ public class RandomEventManager {
             var data = PlayerDataManager.ensureData(uuid, minecraftServer);
 
             if (data.eventTimestamp < currentTime) {
-                var random = minecraftServer.overworld().getRandomSequence(E418.resLoc("event_engine/random_player"));
+                var random = E418Random.EVENT_ENGINE_GLOBAL;
                 // Start event
 
                 // Get nearby players
@@ -120,7 +121,7 @@ public class RandomEventManager {
         if (timeToGlobalEvent <= 0) {
             var cause = new GlobalRandomEventCause();
 
-            var random = minecraftServer.overworld().getRandomSequence(E418.resLoc("event_engine/random_global"));
+            var random = E418Random.EVENT_ENGINE_PLAYER;
 
             var success = false;
             var ctx = new EventContext(minecraftServer)

--- a/common/src/main/java/ru/maxthetomas/e418/event/engine/RandomEventManager.java
+++ b/common/src/main/java/ru/maxthetomas/e418/event/engine/RandomEventManager.java
@@ -13,26 +13,17 @@ import ru.maxthetomas.e418.event.registry.EventRegistries;
 import ru.maxthetomas.e418.player.PlayerDataManager;
 import ru.maxthetomas.e418.util.Location;
 
-import java.util.Random;
-
 public class RandomEventManager {
     private static final Logger LOGGER = LogUtils.getLogger();
-    private static final Random RANDOM = new Random();
 
     // TODO: Put this into config
     private static final int GROUP_DISTANCE = 50;
-    private static final int LOCK_DURATION = 2400;
 
     private static int timeToGlobalEvent = 20 * 60 * 30;
 
     public RandomEventManager() {
         TickEvent.SERVER_POST.register(this::tick);
-        // TODO: VALUES FROM config
-        refreshTimer(1200, 2400);
-    }
-
-    private static void refreshTimer(int min, int max) {
-        timeToGlobalEvent = min + RANDOM.nextInt(max - min);
+        // TODO: Load time from save data
     }
 
     public static int getTimeToGlobalEvent() {
@@ -52,6 +43,7 @@ public class RandomEventManager {
             var data = PlayerDataManager.ensureData(uuid, minecraftServer);
 
             if (data.eventTimestamp < currentTime) {
+                var random = minecraftServer.overworld().getRandomSequence(E418.resLoc("event_engine/random_player"));
                 // Start event
 
                 // Get nearby players
@@ -70,7 +62,7 @@ public class RandomEventManager {
                 // We prevent event start if there's a player with lock nearby.
                 if (hasLocks) {
                     // TODO: Randomize delay with config
-                    var randomDelay = 600;
+                    var randomDelay = random.nextInt(600, 1200);
                     data.eventTimestamp = currentTime + randomDelay;
                     continue;
                 }
@@ -78,13 +70,12 @@ public class RandomEventManager {
 
                 var cause = new PlayerRandomEventCause(uuid);
 
-                // TODO: Only go through valid random events
                 var success = false;
                 var ctx = new EventContext(minecraftServer)
                         .withPlayer(player)
                         .withLocation(Location.fromPlayer(player))
                         .withCause(cause);
-                var e = EventRegistries.getQueueableEventsWithTag("random.player", ctx).getRandomElement();
+                var e = EventRegistries.getQueueableEventsWithTag("random.player", ctx).getRandomElement(random);
 
                 if (e != null) {
                     success = E418.getEventManager().queueEvent(e, ctx);
@@ -92,10 +83,13 @@ public class RandomEventManager {
 
                 if (success) {
                     // TODO: Randomize delay with config
-                    var randomDelay = 600;
-                    var randomOffset = 600;
+
+                    var randomDelay = random.nextInt(600, 1200);
+                    var randomOffset = random.nextInt(600, 1200);
+                    var randomLock = random.nextInt(2000, 2400);
+
                     data.eventTimestamp = currentTime + randomDelay + randomOffset;
-                    data.eventUnlockTimestamp = currentTime + LOCK_DURATION;
+                    data.eventUnlockTimestamp = currentTime + randomLock;
 
                     // Delay event time for players nearby
                     if (success && !cause.isGroupEffectCancelled() && GROUP_DISTANCE > 0) {
@@ -110,7 +104,7 @@ public class RandomEventManager {
 
                             // Linear offset reduction based on how far you are from player.
                             otherData.eventTimestamp += (long) (((double) randomOffset / GROUP_DISTANCE) * (GROUP_DISTANCE - distance));
-                            otherData.eventUnlockTimestamp = currentTime + LOCK_DURATION;
+                            otherData.eventUnlockTimestamp = currentTime + randomLock;
                         }
                     }
                 } else {
@@ -126,11 +120,12 @@ public class RandomEventManager {
         if (timeToGlobalEvent <= 0) {
             var cause = new GlobalRandomEventCause();
 
-            // TODO: Only go through valid random events
+            var random = minecraftServer.overworld().getRandomSequence(E418.resLoc("event_engine/random_global"));
+
             var success = false;
             var ctx = new EventContext(minecraftServer)
                     .withCause(cause);
-            var e = EventRegistries.getQueueableEventsWithTag("random.global", ctx).getRandomElement();
+            var e = EventRegistries.getQueueableEventsWithTag("random.global", ctx).getRandomElement(random);
 
             if (e != null) {
                 success = E418.getEventManager().queueEvent(e, ctx);
@@ -138,9 +133,9 @@ public class RandomEventManager {
 
             // TODO: Put these values to config
             if (success) {
-                refreshTimer(2400, 4800);
+                timeToGlobalEvent = random.nextInt(2400, 4800);
             } else {
-                refreshTimer(1200, 2400);
+                timeToGlobalEvent = random.nextInt(1200, 2400);
             }
         }
     }

--- a/common/src/main/java/ru/maxthetomas/e418/event/registry/EventRegistry.java
+++ b/common/src/main/java/ru/maxthetomas/e418/event/registry/EventRegistry.java
@@ -2,12 +2,16 @@ package ru.maxthetomas.e418.event.registry;
 
 import com.mojang.logging.LogUtils;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import org.slf4j.Logger;
 import ru.maxthetomas.e418.config.SourceConfig;
 import ru.maxthetomas.e418.event.EventResource;
 import ru.maxthetomas.e418.util.WeightedList;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 /**
  * Registry that contains events. Can be configured through from config through {@linkplain SourceConfig} and it's variations.
@@ -47,7 +51,7 @@ public class EventRegistry {
      * @param random Random number supplier to use for selecting an event.
      * @return Randomly picked event.
      */
-    public EventResource getRandomEvent(Random random) {
+    public EventResource getRandomEvent(RandomSource random) {
         return events.getRandomElement(random);
     }
 
@@ -57,7 +61,7 @@ public class EventRegistry {
     public EventResource getRandomEvent() {
         // Todo: avoid using new Random()'s
 //        LOGGER.warn("New random created when getting random event in registry {}", id);
-        return getRandomEvent(new Random());
+        return getRandomEvent(RandomSource.create());
     }
 
     public List<WeightedList.Entry<EventResource>> getEvents() {
@@ -72,5 +76,6 @@ public class EventRegistry {
         return id;
     }
 
-    public record WeightedEvent(EventResource resource, int weight) { }
+    public record WeightedEvent(EventResource resource, int weight) {
+    }
 }

--- a/common/src/main/java/ru/maxthetomas/e418/mixin/common/ServerLevelMixin.java
+++ b/common/src/main/java/ru/maxthetomas/e418/mixin/common/ServerLevelMixin.java
@@ -26,6 +26,7 @@ import ru.maxthetomas.e418.config.Config;
 import ru.maxthetomas.e418.event.EventContext;
 import ru.maxthetomas.e418.event.cause.impl.WakeUpEventCause;
 import ru.maxthetomas.e418.event.registry.EventRegistries;
+import ru.maxthetomas.e418.util.E418Random;
 import ru.maxthetomas.e418.util.E418Variables;
 
 import java.util.List;
@@ -87,7 +88,7 @@ public abstract class ServerLevelMixin {
 
             var cancelTimeSkip = false;
 
-            var random = this.getRandomSequence(E418.resLoc("event_engine/random_player"));
+            var random = E418Random.EVENT_ENGINE_WAKE_UP;
 
             if (random.nextFloat() > 0.5) {
                 var cause = new WakeUpEventCause();

--- a/common/src/main/java/ru/maxthetomas/e418/mixin/common/ServerLevelMixin.java
+++ b/common/src/main/java/ru/maxthetomas/e418/mixin/common/ServerLevelMixin.java
@@ -1,9 +1,11 @@
 package ru.maxthetomas.e418.mixin.common;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.SleepStatus;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.GameRules;
@@ -59,6 +61,9 @@ public abstract class ServerLevelMixin {
     @Shadow
     public abstract @NotNull MinecraftServer getServer();
 
+    @Shadow
+    public abstract RandomSource getRandomSequence(ResourceLocation arg);
+
     @ModifyVariable(at = @At("STORE"), method = "tick", ordinal = 0)
     public int modifySleepingPercentage(int input) {
         return 101; // Disable sleep through night logic.
@@ -82,18 +87,20 @@ public abstract class ServerLevelMixin {
 
             var cancelTimeSkip = false;
 
+            var random = this.getRandomSequence(E418.resLoc("event_engine/random_player"));
 
-            // TODO: Randomize so not every wake up will cause an event.
-            var cause = new WakeUpEventCause();
-            var ctx = new EventContext(this.getServer())
-                    .withCause(cause);
-            var e = EventRegistries.getQueueableEventsWithTag("action.minecraft.wake_up", ctx).getRandomElement();
+            if (random.nextFloat() > 0.5) {
+                var cause = new WakeUpEventCause();
+                var ctx = new EventContext(this.getServer())
+                        .withCause(cause);
+                var e = EventRegistries.getQueueableEventsWithTag("action.minecraft.wake_up", ctx).getRandomElement(random);
 
-            if (e != null) {
-                E418.getEventManager().queueEvent(e, ctx);
+                if (e != null) {
+                    E418.getEventManager().queueEvent(e, ctx);
+                }
+
+                cancelTimeSkip = cause.isTimeSkipCancelled();
             }
-
-            cancelTimeSkip = cause.isTimeSkipCancelled();
 
             if (!cancelTimeSkip && this.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)) {
                 var l = this.serverLevelData.getDayTime() + 24000L;

--- a/common/src/main/java/ru/maxthetomas/e418/util/E418Random.java
+++ b/common/src/main/java/ru/maxthetomas/e418/util/E418Random.java
@@ -1,0 +1,25 @@
+package ru.maxthetomas.e418.util;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.RandomSource;
+import ru.maxthetomas.e418.E418;
+
+public class E418Random {
+    public static RandomSource EVENT_ENGINE_GLOBAL;
+    public static RandomSource EVENT_ENGINE_PLAYER;
+    public static RandomSource EVENT_ENGINE_WAKE_UP;
+    public static RandomSource EVENT_ENGINE_CHAT;
+    public static RandomSource EVENT_GENERIC;
+
+    public static void init(MinecraftServer server) {
+        var level = server.overworld();
+
+        EVENT_ENGINE_GLOBAL = level.getRandomSequence(E418.resLoc("event_engine/random_global"));
+        EVENT_ENGINE_PLAYER = level.getRandomSequence(E418.resLoc("event_engine/random_player"));
+        EVENT_ENGINE_WAKE_UP = level.getRandomSequence(E418.resLoc("event_engine/wake_up"));
+        EVENT_ENGINE_CHAT = level.getRandomSequence(E418.resLoc("event_engine/chat"));
+        EVENT_GENERIC = level.getRandomSequence(E418.resLoc("event/generic"));
+    }
+
+
+}

--- a/common/src/main/java/ru/maxthetomas/e418/util/E418Random.java
+++ b/common/src/main/java/ru/maxthetomas/e418/util/E418Random.java
@@ -1,6 +1,6 @@
 package ru.maxthetomas.e418.util;
 
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import ru.maxthetomas.e418.E418;
 
@@ -11,8 +11,8 @@ public class E418Random {
     public static RandomSource EVENT_ENGINE_CHAT;
     public static RandomSource EVENT_GENERIC;
 
-    public static void init(MinecraftServer server) {
-        var level = server.overworld();
+    public static void init(ServerLevel level) {
+        //var level = server.overworld();
 
         EVENT_ENGINE_GLOBAL = level.getRandomSequence(E418.resLoc("event_engine/random_global"));
         EVENT_ENGINE_PLAYER = level.getRandomSequence(E418.resLoc("event_engine/random_player"));

--- a/common/src/main/java/ru/maxthetomas/e418/util/E418Random.java
+++ b/common/src/main/java/ru/maxthetomas/e418/util/E418Random.java
@@ -1,5 +1,6 @@
 package ru.maxthetomas.e418.util;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import ru.maxthetomas.e418.E418;
@@ -11,14 +12,14 @@ public class E418Random {
     public static RandomSource EVENT_ENGINE_CHAT;
     public static RandomSource EVENT_GENERIC;
 
-    public static void init(ServerLevel level) {
-        //var level = server.overworld();
+    public static ResourceLocation EVENT_GENERIC_RESOURCE = E418.resLoc("event/generic");
 
+    public static void init(ServerLevel level) {
         EVENT_ENGINE_GLOBAL = level.getRandomSequence(E418.resLoc("event_engine/random_global"));
         EVENT_ENGINE_PLAYER = level.getRandomSequence(E418.resLoc("event_engine/random_player"));
         EVENT_ENGINE_WAKE_UP = level.getRandomSequence(E418.resLoc("event_engine/wake_up"));
         EVENT_ENGINE_CHAT = level.getRandomSequence(E418.resLoc("event_engine/chat"));
-        EVENT_GENERIC = level.getRandomSequence(E418.resLoc("event/generic"));
+        EVENT_GENERIC = level.getRandomSequence(EVENT_GENERIC_RESOURCE);
     }
 
 

--- a/common/src/main/java/ru/maxthetomas/e418/util/WeightedList.java
+++ b/common/src/main/java/ru/maxthetomas/e418/util/WeightedList.java
@@ -1,15 +1,18 @@
 package ru.maxthetomas.e418.util;
 
-import java.util.*;
+import net.minecraft.util.RandomSource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class WeightedList<T> {
     public List<Entry<T>> values = new ArrayList<>();
 
-    public void add(int weight, T value){
+    public void add(int weight, T value) {
         values.add(new Entry<>(weight, value));
     }
 
-    public T getRandomElement(Random random) {
+    public T getRandomElement(RandomSource random) {
         if (values.isEmpty()) {
             return null;
         }
@@ -33,10 +36,10 @@ public class WeightedList<T> {
     }
 
     /**
-     * Executes {@code getRandomEvent} with a new {@linkplain Random}
+     * Executes {@code getRandomEvent} with a new {@linkplain RandomSource}
      */
     public T getRandomElement() {
-        return getRandomElement(new Random());
+        return getRandomElement(RandomSource.create());
     }
 
     public void clear() {
@@ -55,6 +58,7 @@ public class WeightedList<T> {
         return values.size();
     }
 
-    public record Entry<T>(int weight, T element) {}
+    public record Entry<T>(int weight, T element) {
+    }
 }
 


### PR DESCRIPTION
Use random sequence for each case with RNG usage. Use minecraft's `RandomSource` instead java's `Random` 

It probably wouldn't make players able to change event seed to reliably change how events will go. A lot of cases when sequence can shift or possible events change, which results in change of future random events.

Also need ResourceLocation for events to make possible use default name for undefined random sequenced in events. Currently they use overworld's random source