### PR TITLE
feat: hide self-spoilers in brigadier command suggestions

### DIFF
--- a/common/src/main/java/ru/maxthetomas/e418/mixin/common/SharedSuggestionProviderMixin.java
+++ b/common/src/main/java/ru/maxthetomas/e418/mixin/common/SharedSuggestionProviderMixin.java
@@ -1,0 +1,88 @@
+package ru.maxthetomas.e418.mixin.common;
+
+import com.google.common.base.Strings;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import ru.maxthetomas.e418.config.Config;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@Mixin(SharedSuggestionProvider.class)
+public interface SharedSuggestionProviderMixin {
+    @Inject(
+            method = "filterResources(Ljava/lang/Iterable;Ljava/lang/String;Ljava/util/function/Function;Ljava/util/function/Consumer;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private static <T> void patchFilterResources(
+            Iterable<T> iterable,
+            String string,
+            Function<T, ResourceLocation> function,
+            Consumer<T> consumer,
+            CallbackInfo ci
+    ) {
+        if (!Config.isDebug()) return;
+
+        boolean bl = string.indexOf(':') > -1;
+
+        for (T object : iterable) {
+            ResourceLocation resourceLocation = function.apply(object);
+
+            // Skip if starts with "e418"
+            if (resourceLocation.toString().startsWith("e418")) {
+                continue;
+            }
+
+            if (bl) {
+                String string2 = resourceLocation.toString();
+                if (SharedSuggestionProvider.matchesSubStr(string, string2)) {
+                    consumer.accept(object);
+                }
+            } else if (SharedSuggestionProvider.matchesSubStr(string, resourceLocation.getNamespace())
+                    || (resourceLocation.getNamespace().equals("minecraft")
+                    && SharedSuggestionProvider.matchesSubStr(string, resourceLocation.getPath()))) {
+                consumer.accept(object);
+            }
+        }
+
+        ci.cancel();
+    }
+
+    @Inject(
+            method = "filterResources(Ljava/lang/Iterable;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;Ljava/util/function/Consumer;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private static <T> void patchFilterResources2(
+            Iterable<T> iterable,
+            String string,
+            String string2,
+            Function<T, ResourceLocation> function,
+            Consumer<T> consumer,
+            CallbackInfo ci
+    ) {
+        if (!Config.isDebug()) return;
+
+        if (string.isEmpty()) {
+            iterable.forEach(object -> {
+                ResourceLocation rl = function.apply(object);
+                if (!rl.toString().startsWith("e418")) {
+                    consumer.accept(object);
+                }
+            });
+        } else {
+            String string3 = Strings.commonPrefix(string, string2);
+            if (!string3.isEmpty()) {
+                String string5 = string.substring(string3.length());
+                SharedSuggestionProvider.filterResources(iterable, string5, function, consumer);
+            }
+        }
+
+        ci.cancel();
+    }
+}

--- a/common/src/main/resources/e418.mixins.json
+++ b/common/src/main/resources/e418.mixins.json
@@ -9,11 +9,11 @@
     "client.DebugScreenOverlayMixin",
     "client.GameRendererMixin",
     "client.LevelRendererMixin",
+    "client.PauseScreenMixin",
+    "client.SkyRendererMixin",
     "client.TextureAtlasSpriteMixin",
     "client.WeatherEffectRendererMixin",
-    "client.WorldOpenFlowsMixin",
-    "client.SkyRendererMixin",
-    "client.PauseScreenMixin"
+    "client.WorldOpenFlowsMixin"
   ],
   "mixins": [
     "client.TextureManagerMixin",
@@ -21,6 +21,7 @@
     "common.EntityMixin",
     "common.MsgCommandMixin",
     "common.ServerLevelMixin",
+    "common.SharedSuggestionProviderMixin",
     "common.SnowAndFreezeFeatureMixin",
     "common.StructureManagerMixin"
   ],


### PR DESCRIPTION
This replaces the common Minecraft's filters for suggestions and will not work for non-vanilla commands that interact with resource locations.
